### PR TITLE
Feat 레일 상태 undo & reset 기능 추가

### DIFF
--- a/src/components/ui/editor/EditorActionControls.jsx
+++ b/src/components/ui/editor/EditorActionControls.jsx
@@ -16,6 +16,8 @@ const EditorActionControls = () => {
   const navigate = useNavigate();
   const placedRails = useSceneStore((state) => state.placedRails);
   const setCoasterPath = useSceneStore((state) => state.setCoasterPath);
+  const undoRail = useSceneStore((state) => state.undoRail);
+  const resetRails = useSceneStore((state) => state.resetRails);
 
   const handlePlayClick = () => {
     if (!isRailConnected()) {
@@ -46,10 +48,12 @@ const EditorActionControls = () => {
     {
       key: 'undo',
       icon: RiArrowGoBackFill,
+      onClick: undoRail,
     },
     {
       key: 'reset',
       icon: RiResetLeftFill,
+      onClick: resetRails,
     },
   ];
 

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -28,8 +28,8 @@ export const useSceneStore = create((set) => ({
         };
       }
 
-      const newHistory = [...state.railHistory];
-      const previous = newHistory.pop();
+      const previous = state.railHistory[state.railHistory.length - 2];
+      const newHistory = state.railHistory.slice(0, -1);
 
       return {
         placedRails: previous,

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -1,14 +1,40 @@
 import { create } from 'zustand';
 
+import { INITIAL_RAILS } from '@/constants/initialRails';
+
 export const useSceneStore = create((set) => ({
   selectedItem: null,
   selectedRail: null,
   coasterPath: null,
   placedItems: [],
   placedRails: [],
+  railHistory: [],
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
   setCoasterPath: (path) => set({ coasterPath: path }),
   setPlacedItems: (item) => set({ placedItems: item }),
-  setPlacedRails: (rail) => set({ placedRails: rail }),
+  setPlacedRails: (rails) =>
+    set((state) => ({
+      placedRails: rails,
+      railHistory: [...state.railHistory, state.placedRails],
+    })),
+  undoRail: () =>
+    set((state) => {
+      if (state.railHistory.length === 0) {
+        return {};
+      }
+
+      const newHistory = [...state.railHistory];
+      const previous = newHistory.pop();
+
+      return {
+        placedRails: previous,
+        railHistory: newHistory,
+      };
+    }),
+  resetRails: () =>
+    set(() => ({
+      placedRails: [...INITIAL_RAILS],
+      railHistory: [],
+    })),
 }));

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -7,8 +7,8 @@ export const useSceneStore = create((set) => ({
   selectedRail: null,
   coasterPath: null,
   placedItems: [],
-  placedRails: [],
-  railHistory: [],
+  placedRails: [...INITIAL_RAILS],
+  railHistory: [[...INITIAL_RAILS]],
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
   setCoasterPath: (path) => set({ coasterPath: path }),
@@ -16,12 +16,16 @@ export const useSceneStore = create((set) => ({
   setPlacedRails: (rails) =>
     set((state) => ({
       placedRails: rails,
-      railHistory: [...state.railHistory, state.placedRails],
+      railHistory: [...state.railHistory, [...state.placedRails]],
     })),
+
   undoRail: () =>
     set((state) => {
-      if (state.railHistory.length === 0) {
-        return {};
+      if (state.railHistory.length <= 1) {
+        return {
+          placedRails: state.railHistory[0],
+          railHistory: state.railHistory,
+        };
       }
 
       const newHistory = [...state.railHistory];
@@ -32,9 +36,10 @@ export const useSceneStore = create((set) => ({
         railHistory: newHistory,
       };
     }),
+
   resetRails: () =>
     set(() => ({
       placedRails: [...INITIAL_RAILS],
-      railHistory: [],
+      railHistory: [[...INITIAL_RAILS]],
     })),
 }));


### PR DESCRIPTION
## 🔗 Related Issue
- close #60 

## 📝 Done Task
- [x] Undo 기능 (되돌리기)
- [x] Undo 이후 레일 설치 시, 히스토리 스택 초기화
- [x] Reset 기능

## 🔎 PR Point
- 잘못된 방향으로 레일을 설치했거나, 최종 단계에서 되돌아갈 수 있는 기능이 필요하다는 피드백을 반영해 **Undo 및 Reset 기능**을 추가했습니다.
- 사용자가 이전 레일 상태로 되돌아갈 수 있도록 `undo` 기능을 구현했습니다.
- 전체 초기화가 필요한 경우를 위해 `reset` 기능도 함께 제공됩니다.
- 레일을 배치할 때마다, 기존 `placedRails` 상태를 `railHistory`에 스택 형태로 저장합니다.
- `undoRail()` 호출 시 `railHistory`의 마지막 상태를 pop하여 복원합니다.

📌예시
1. 현재 `placedRails` = [A, B]
2. 레일 C 추가 → [A, B, C] 
👉 `railHistory`에 [A, B] 저장됨
3. `undoRail()` 실행 → [A, B] 복원

## 💣 Trouble Shooting
**문제 1** : `zustand `상태 업데이트 방식이 익숙하지 않아, 아래 개념들을 처음에 명확하게 이해하기 어려웠습니다.
- return {}가 의미하는 바가 무엇인지
- 상태 전체가 사라지진 않는지
- undo 기능에 `railHistory`가 정말 필요한지


**해결방법** 
- 우선 단순히 이전 상태를 상태 1단계만 기억하는 방식(`prevPlacedRails`)과 스택 기반의 **undo** (`railHistory`) 구조의 차이를 비교해 보았습니다.
- 이전 방식에서는 **undo** 버튼을 한 번 누른 이후 더 이상 상태가 저장되지 않아, 연속으로 여러 번 되돌리는 기능이 작동하지 않는 문제를 확인했습니다.
- 이에 따라, 상태의 이력을 스택구조로 관리하는 방식으로 전환하였고, 이전 상태들을 순차적으로 되돌릴 수 있는 **railHistory** 기반 **undo** 로직을 설계하고, 상태 손실 없이 되돌리기가 가능하도록 구현했습니다.

**문제 2** : 초기 렌더링 후 **undo** 버튼을 여러 번 클릭하면 `placedRails`가 빈 배열이 되어 이후 레일 설치 시 `.endPoin.endPoint`에 접근할 수 없어 오류가 발생하였습니다.

**해결방법** 
- 빈 배열 상태에서 마지막 레일의 `.endPoint`를 참조하려다 보니 `undefined`에서 속성을 읽는 오류가 발생한 것을 확인하였습니다.
- 초기 상태(`INITIAL_RAILS`)를 `railHistory`에 포함시켜 최소 하나 이상의 상태가 항상 유지되도록 했습니다.
- 그리고  `railHistory.length <= 1`일 때는 더 이상 `undo `되지 않도록 로직을 추가했습니다.

https://github.com/user-attachments/assets/6a032b35-b414-4e7c-9529-cf834b62e2d5

## 📸 Screenshot

1. Undo & Reset

https://github.com/user-attachments/assets/af408df8-3052-464e-917f-bc67f3860d2c

