### PR TITLE
Feat:  레일 기울기 기반 속도 조절 및 전체 배속 조절 기능 구현

### DIFF
--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -9,6 +9,7 @@ const CartFollower = () => {
   const cartRef = useRef();
   const [progress, setProgress] = useState(0);
   const coasterPath = useSceneStore((state) => state.coasterPath);
+  const simulationSpeed = useSceneStore((state) => state.simulationSpeed);
 
   const { scene: cart } = useGLTF('/objects/cart.glb');
 
@@ -30,7 +31,7 @@ const CartFollower = () => {
       speed = Math.max(speed, MIN_SPEED);
     }
 
-    const newProgress = Math.min(progress + delta * speed, 1);
+    const newProgress = Math.min(progress + delta * speed * simulationSpeed, 1);
 
     setProgress(newProgress);
 

--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -12,19 +12,30 @@ const CartFollower = () => {
 
   const { scene: cart } = useGLTF('/objects/cart.glb');
 
+  const BASE_SPEED = 0.3;
+  const SPEED_REDUCTION = 0.3;
+  const MIN_SPEED = 0.05;
+
   useFrame((_, delta) => {
     if (!coasterPath || !cartRef.current) {
       return;
     }
 
-    const speed = 0.2;
+    const direction = coasterPath.getTangentAt(progress);
+
+    let speed = BASE_SPEED;
+
+    if (direction.y > 0) {
+      speed = BASE_SPEED - direction.y * SPEED_REDUCTION;
+      speed = Math.max(speed, MIN_SPEED);
+    }
+
     const newProgress = Math.min(progress + delta * speed, 1);
 
     setProgress(newProgress);
 
     const cartHeightOffset = 2;
     const currentPosition = coasterPath.getPointAt(newProgress);
-    const direction = coasterPath.getTangentAt(newProgress);
 
     const { rotationQuaternion, adjustedUp } = getRotationFromDirection(direction);
 

--- a/src/components/ui/modal/SpeedSettingModal.jsx
+++ b/src/components/ui/modal/SpeedSettingModal.jsx
@@ -2,9 +2,16 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 
 import ModalLayout from '@/components/ui/modal/ModalLayout';
+import { useSceneStore } from '@/store/useSceneStore';
 
 const SpeedSettingModal = ({ onCancel, onStart }) => {
-  const [speed, setSpeed] = useState(1);
+  const [sliderSpeed, setSliderSpeed] = useState(1);
+  const setSimulationSpeed = useSceneStore((state) => state.setSimulationSpeed);
+
+  const handleStart = () => {
+    setSimulationSpeed(sliderSpeed);
+    onStart();
+  };
 
   return (
     <ModalLayout>
@@ -16,11 +23,13 @@ const SpeedSettingModal = ({ onCancel, onStart }) => {
           min="0.5"
           max="2"
           step="0.1"
-          value={speed}
-          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+          value={sliderSpeed}
+          onChange={(e) => setSliderSpeed(parseFloat(e.target.value))}
           className="w-full cursor-pointer appearance-none rounded-lg border-1 border-amber-300 bg-white accent-yellow-300 dark:bg-gray-700"
         />
-        <p className="mt-2 text-center text-lg font-semibold">현재 속도: {speed.toFixed(1)}x</p>
+        <p className="mt-2 text-center text-lg font-semibold">
+          현재 속도: {sliderSpeed.toFixed(1)}x
+        </p>
       </div>
       <footer className="flex justify-center gap-5">
         <button
@@ -33,7 +42,7 @@ const SpeedSettingModal = ({ onCancel, onStart }) => {
         <button
           type="button"
           className="w-full rounded-lg border border-yellow-400 px-4 py-2 hover:bg-yellow-300"
-          onClick={onStart}
+          onClick={handleStart}
         >
           시작
         </button>

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -9,6 +9,7 @@ export const useSceneStore = create((set) => ({
   placedItems: [],
   placedRails: [...INITIAL_RAILS],
   railHistory: [[...INITIAL_RAILS]],
+  simulationSpeed: 1,
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
   setCoasterPath: (path) => set({ coasterPath: path }),
@@ -18,6 +19,7 @@ export const useSceneStore = create((set) => ({
       placedRails: rails,
       railHistory: [...state.railHistory, [...state.placedRails]],
     })),
+  setSimulationSpeed: (value) => set({ simulationSpeed: value }),
 
   undoRail: () =>
     set((state) => {


### PR DESCRIPTION
## 🔗 Related Issue
- close #69 

## 📝 Done Task
- [x] 오르막 경사에 따라 속도 자동 조절 (기울기 기반 감속)
- [x] 전체 배속 조절 기능 구현 (모달에서 조절값 설정 → 카트 주행 속도에 곱해 적용)

## 🔎 PR Point
- **CartFollower** 내부에서 경사도 기반 속도 감속 로직을 추가했습니다.
  - `coasterPath.getTangentAt(progress).y` 값을 활용해 오르막일수록 `BASE_SPEED`에서 감산되도록 설정했습니다.
  - 너무 느려지는 현상을 방지하기 위해 최소 속도 `MIN_SPEED`를 설정했습니다.
-  시뮬레이션 시작 전, 모달에서 설정한 배속을 적용했습니다.
  - **useSceneStore**의 `simulationSpeed` 전역 상태를 도입해, 카트 속도에 배속 곱이 적용되도록 구성했습니다.

## 📸 Screenshot

경사도 기반 속도 감속 적용

https://github.com/user-attachments/assets/f4b66bc9-5125-4219-a4f3-69cfd8f1549b

속도 배속 적용

https://github.com/user-attachments/assets/62a2b307-7a85-41e5-bd29-2b9e2dfe02f3




