### PR TITLE
Feat: 시뮬레이션 재시작 로직 구현

### DIFF
--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -2,13 +2,10 @@ import { useGLTF } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 
+import { BASE_CART_SPEED, MIN_CART_SPEED, SPEED_REDUCTION } from '@/constants/cartSpeed';
 import { SIMULATION_CAMERA } from '@/constants/simulationCamera';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getRotationFromDirection } from '@/utils/getRotationFromDirection';
-
-const BASE_SPEED = 0.3;
-const SPEED_REDUCTION = 0.3;
-const MIN_SPEED = 0.05;
 
 const CartFollower = () => {
   const cartRef = useRef();
@@ -56,6 +53,16 @@ const CartFollower = () => {
     }
   };
 
+  const getCartSpeed = (direction) => {
+    if (direction.y > 0) {
+      const reducedSpeed = BASE_CART_SPEED - direction.y * SPEED_REDUCTION;
+
+      return Math.max(reducedSpeed, MIN_CART_SPEED);
+    }
+
+    return BASE_CART_SPEED;
+  };
+
   useEffect(() => {
     setSimulationProgress(0);
   }, []);
@@ -65,15 +72,9 @@ const CartFollower = () => {
       return;
     }
     const direction = coasterPath.getTangentAt(simulationProgress);
+    const cartSpeed = getCartSpeed(direction);
 
-    let speed = BASE_SPEED;
-
-    if (direction.y > 0) {
-      speed = BASE_SPEED - direction.y * SPEED_REDUCTION;
-      speed = Math.max(speed, MIN_SPEED);
-    }
-
-    const nextProgress = Math.min(simulationProgress + delta * speed * simulationSpeed, 1);
+    const nextProgress = Math.min(simulationProgress + delta * cartSpeed * simulationSpeed, 1);
 
     setSimulationProgress(nextProgress);
     updateCartAndCamera(nextProgress, direction);

--- a/src/components/ui/simulation/RestartButton.jsx
+++ b/src/components/ui/simulation/RestartButton.jsx
@@ -1,0 +1,20 @@
+import { FaCar } from 'react-icons/fa';
+
+import { useSceneStore } from '@/store/useSceneStore';
+
+const RestartButton = () => {
+  const setSimulationProgress = useSceneStore((state) => state.setSimulationProgress);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setSimulationProgress(0)}
+      className="absolute top-5 right-5 flex items-center gap-2 rounded-full bg-blue-500 px-4 py-3 text-sm font-semibold text-white shadow-md hover:scale-105 active:scale-95"
+    >
+      <FaCar />
+      다시 타기
+    </button>
+  );
+};
+
+export default RestartButton;

--- a/src/components/ui/simulation/SwitchViewButton.jsx
+++ b/src/components/ui/simulation/SwitchViewButton.jsx
@@ -5,6 +5,7 @@ import { useSceneStore } from '@/store/useSceneStore';
 const SwitchViewButton = () => {
   const viewMode = useSceneStore((state) => state.viewMode);
   const toggleViewMode = useSceneStore((state) => state.toggleViewMode);
+
   const icon = viewMode === 'firstPerson' ? <FaUser /> : <FaEye />;
   const label = viewMode === 'firstPerson' ? '3인칭 보기' : '1인칭 보기';
 
@@ -12,7 +13,7 @@ const SwitchViewButton = () => {
     <button
       type="button"
       onClick={toggleViewMode}
-      className="absolute top-5 right-5 z-10 flex items-center gap-2 rounded-full bg-yellow-300 px-4 py-3 text-sm font-semibold text-black shadow transition hover:scale-105 active:scale-95"
+      className="absolute top-5 right-5 flex items-center gap-2 rounded-full bg-yellow-300 px-4 py-3 text-sm font-semibold text-black shadow transition hover:scale-105 active:scale-95"
       title="시점 전환"
     >
       {icon}

--- a/src/constants/cartSpeed.js
+++ b/src/constants/cartSpeed.js
@@ -1,0 +1,3 @@
+export const BASE_CART_SPEED = 0.3;
+export const SPEED_REDUCTION = 0.3;
+export const MIN_CART_SPEED = 0.05;

--- a/src/pages/Simulation.jsx
+++ b/src/pages/Simulation.jsx
@@ -1,11 +1,15 @@
 import SimulationCanvas from '@/components/canvas/SimulationCanvas';
+import RestartButton from '@/components/ui/simulation/RestartButton';
 import SwitchViewButton from '@/components/ui/simulation/SwitchViewButton';
+import { useSceneStore } from '@/store/useSceneStore';
 
 const Simulation = () => {
+  const simulationProgress = useSceneStore((state) => state.simulationProgress);
+
   return (
     <main className="h-full">
       <SimulationCanvas />
-      <SwitchViewButton />
+      {simulationProgress >= 1 ? <RestartButton /> : <SwitchViewButton />}
     </main>
   );
 };

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -11,6 +11,7 @@ export const useSceneStore = create((set) => ({
   railHistory: [[...INITIAL_RAILS]],
   viewMode: 'thirdPerson',
   simulationSpeed: 1,
+  simulationProgress: 0,
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
   setCoasterPath: (path) => set({ coasterPath: path }),
@@ -25,6 +26,7 @@ export const useSceneStore = create((set) => ({
       viewMode: state.viewMode === 'firstPerson' ? 'thirdPerson' : 'firstPerson',
     })),
   setSimulationSpeed: (value) => set({ simulationSpeed: value }),
+  setSimulationProgress: (value) => set({ simulationProgress: value }),
   undoRail: () =>
     set((state) => {
       if (state.railHistory.length <= 1) {


### PR DESCRIPTION
## 🔗 Related Issue
- close #76

## 📝 Done Task
- [x] 주행 진행 상태를 로컬 상태(`progress`)에서 전역 상태(`simulationProgress`)로 이동
- [x] “다시 타기” 버튼 클릭 시 `simulationProgress`를 0으로 초기화하여 주행을 재시작할 수 있도록 구현
- [x] 시뮬레이션 UI 버튼을 조건부로 분기 렌더링
주행 중(`simulationProgress< 1`)에는 시점 전환 버튼
주행 종료(`simulationProgress>= 1`) 시에는 다시 타기 버튼 표시  
- [x] 카트 주행 속도 관련 상수를 `constants/cartSpeed.js`로 분리
- [x] 주행 속도 계산 로직을 함수로 추출하여 가독성 및 재사용성 향상 

## 🔎 PR Point
- 기존에는 CartFollower 내부에서 로컬 상태로 주행 진행도를 관리하고 있었는데,
이를 전역 상태로 이동시킴으로써 다른 컴포넌트에서도 주행 진행 상황에 접근하거나 제어할 수 있도록 확장했습니다.
- 시점 전환 버튼과 다시 타기 버튼을 서로 다른 조건에 따라 렌더링하도록 분리했습니다.
- 주행 재시작은 상태 초기화로 구현되며, `simulationProgress`가 0으로 돌아가면 카트 주행이 처음부터 다시 시작됩니다.
- 주행 속도 관련 상수를 별도 파일로 분리하고, 로직을 함수로 추출하여 리팩토링했습니다. 
 
## 📸 Screenshot

https://github.com/user-attachments/assets/a35dc29e-eaf9-4adc-911e-effd25fc0be9

