### PR TITLE
Refactor: 새로고침 시 상태의 불일치 및 유실 문제 개선

### DIFF
--- a/src/pages/Editor.jsx
+++ b/src/pages/Editor.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import EditorCanvas from '@/components/canvas/EditorCanvas';
 import EditorPanel from '@/components/ui/editor/EditorPanel';
@@ -6,11 +6,14 @@ import Slider from '@/components/ui/editor/Slider';
 import { MIN_CAMERA_SPEED } from '@/constants/cameraSensitivity';
 import { INITIAL_RAILS } from '@/constants/initialRails';
 import { usePlaceRails } from '@/hooks/usePlaceRails';
+import { useSceneStore } from '@/store/useSceneStore';
 
 const Editor = () => {
   const [cameraRotationSpeed, setCameraRotationSpeed] = useState(MIN_CAMERA_SPEED);
   const [cameraMoveSpeed, setCameraMoveSpeed] = useState(MIN_CAMERA_SPEED);
-
+  const resetRails = useSceneStore((state) => state.resetRails);
+  const resetItems = useSceneStore((state) => state.resetItems);
+  const setCoasterPath = useSceneStore((state) => state.setCoasterPath);
   const handleRotationSpeedChange = (value) => {
     setCameraRotationSpeed(value);
   };
@@ -20,6 +23,12 @@ const Editor = () => {
   };
 
   usePlaceRails(INITIAL_RAILS);
+
+  useEffect(() => {
+    resetRails();
+    resetItems();
+    setCoasterPath(null);
+  }, []);
 
   return (
     <main className="h-full">

--- a/src/pages/Simulation.jsx
+++ b/src/pages/Simulation.jsx
@@ -1,11 +1,22 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import SimulationCanvas from '@/components/canvas/SimulationCanvas';
 import RestartButton from '@/components/ui/simulation/RestartButton';
 import SwitchViewButton from '@/components/ui/simulation/SwitchViewButton';
 import { useSceneStore } from '@/store/useSceneStore';
 
 const Simulation = () => {
+  const navigate = useNavigate();
   const simulationProgress = useSceneStore((state) => state.simulationProgress);
+  const coasterPath = useSceneStore((state) => state.coasterPath);
   const isSimulationFinished = simulationProgress >= 1;
+
+  useEffect(() => {
+    if (!coasterPath) {
+      navigate('/', { replace: true });
+    }
+  }, [coasterPath, navigate]);
 
   return (
     <main className="h-full">

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -14,17 +14,19 @@ export const useSceneStore = create((set) => ({
   simulationProgress: 0,
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
-  setPlacedItems: (items) => set({ placedItems: items }),
+  setCoasterPath: (path) => set({ coasterPath: path }),
+  setPlacedItems: (item) => set({ placedItems: item }),
   setPlacedRails: (rails) =>
     set((state) => ({
       placedRails: rails,
       railHistory: [...state.railHistory, [...state.placedRails]],
     })),
-  setCoasterPath: (path) => set({ coasterPath: path }),
-  setSimulationSpeed: (speed) => set({ simulationSpeed: speed }),
-  setSimulationProgress: (progress) => set({ simulationProgress: progress }),
-  setViewMode: (mode) => set({ viewMode: mode }),
-
+  toggleViewMode: () =>
+    set((state) => ({
+      viewMode: state.viewMode === 'firstPerson' ? 'thirdPerson' : 'firstPerson',
+    })),
+  setSimulationSpeed: (value) => set({ simulationSpeed: value }),
+  setSimulationProgress: (value) => set({ simulationProgress: value }),
   undoRail: () =>
     set((state) => {
       if (state.railHistory.length <= 1) {
@@ -42,20 +44,13 @@ export const useSceneStore = create((set) => ({
         railHistory: newHistory,
       };
     }),
-
   resetRails: () =>
     set(() => ({
       placedRails: [...INITIAL_RAILS],
       railHistory: [[...INITIAL_RAILS]],
     })),
-
   resetItems: () =>
     set(() => ({
       placedItems: [],
-    })),
-
-  toggleViewMode: () =>
-    set((state) => ({
-      viewMode: state.viewMode === 'firstPerson' ? 'thirdPerson' : 'firstPerson',
     })),
 }));

--- a/src/store/useSceneStore.js
+++ b/src/store/useSceneStore.js
@@ -14,19 +14,17 @@ export const useSceneStore = create((set) => ({
   simulationProgress: 0,
   setSelectedItem: (item) => set({ selectedItem: item }),
   setSelectedRail: (rail) => set({ selectedRail: rail }),
-  setCoasterPath: (path) => set({ coasterPath: path }),
-  setPlacedItems: (item) => set({ placedItems: item }),
+  setPlacedItems: (items) => set({ placedItems: items }),
   setPlacedRails: (rails) =>
     set((state) => ({
       placedRails: rails,
       railHistory: [...state.railHistory, [...state.placedRails]],
     })),
-  toggleViewMode: () =>
-    set((state) => ({
-      viewMode: state.viewMode === 'firstPerson' ? 'thirdPerson' : 'firstPerson',
-    })),
-  setSimulationSpeed: (value) => set({ simulationSpeed: value }),
-  setSimulationProgress: (value) => set({ simulationProgress: value }),
+  setCoasterPath: (path) => set({ coasterPath: path }),
+  setSimulationSpeed: (speed) => set({ simulationSpeed: speed }),
+  setSimulationProgress: (progress) => set({ simulationProgress: progress }),
+  setViewMode: (mode) => set({ viewMode: mode }),
+
   undoRail: () =>
     set((state) => {
       if (state.railHistory.length <= 1) {
@@ -36,7 +34,7 @@ export const useSceneStore = create((set) => ({
         };
       }
 
-      const previous = state.railHistory[state.railHistory.length - 2];
+      const previous = state.railHistory[state.railHistory.length - 1];
       const newHistory = state.railHistory.slice(0, -1);
 
       return {
@@ -44,9 +42,20 @@ export const useSceneStore = create((set) => ({
         railHistory: newHistory,
       };
     }),
+
   resetRails: () =>
     set(() => ({
       placedRails: [...INITIAL_RAILS],
       railHistory: [[...INITIAL_RAILS]],
+    })),
+
+  resetItems: () =>
+    set(() => ({
+      placedItems: [],
+    })),
+
+  toggleViewMode: () =>
+    set((state) => ({
+      viewMode: state.viewMode === 'firstPerson' ? 'thirdPerson' : 'firstPerson',
     })),
 }));


### PR DESCRIPTION
## 🔗 Related Issue
- close #62 

## 📝 Done Task
- [x] undoRail 로직 수정 (railHistory[-2] → [-1])
- [x] Editor 진입 시 상태 초기화 (resetRails, resetItems, setCoasterPath(null))
- [x] Simulation 페이지에서 coasterPath 없을 경우 홈으로 리디렉션

## 🔎 PR Point
- 새로고침 시 상태 휘발로 인해 시뮬레이션 시점이 비정상적으로 고정되는 문제를 해결하였습니다.
→ `coasterPath`가 없을 경우 **홈으로 리디렉션**하여 접근 자체를 차단하였습니다.
- 시뮬레이션 종료 후 에디터 복귀 시 불필요한 레일이 추가되고 key 충돌이 발생하는 문제를 수정하였습니다.
→ 에디터 진입 시 `resetRails()`로 레일 상태를 초기화하였습니다.
- `coasterPath` 유무를 확인하여 잘못된 시뮬레이션 페이지 진입을 차단하였습니다.
→ `useEffect` 내 조건문으로 존재 여부를 검사하고, 없을 경우 강제 이동 처리하였습니다.

## 📸 Screenshot
1. undoRail 수정

https://github.com/user-attachments/assets/2027450d-7101-4159-9188-218a9c129fa6


2. Simulation 페이지

https://github.com/user-attachments/assets/7c1e1885-c298-48b7-bfa1-92d25fbadd47