### PR TITLE
Feat: 시뮬레이션 주행 속도 개선

### DIFF
--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -1,11 +1,10 @@
 import { useGLTF } from '@react-three/drei';
-import { useFrame, useThree } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 
-import { SIMULATION_CAMERA } from '@/constants/simulationCamera';
+import { useSyncCartAndCamera } from '@/hooks/useSyncCartAndCamera';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getCartSpeed } from '@/utils/getCartSpeed';
-import { getRotationFromDirection } from '@/utils/getRotationFromDirection';
 
 const CartFollower = () => {
   const cartRef = useRef();
@@ -13,45 +12,10 @@ const CartFollower = () => {
   const simulationProgress = useSceneStore((state) => state.simulationProgress);
   const setSimulationProgress = useSceneStore((state) => state.setSimulationProgress);
   const coasterPath = useSceneStore((state) => state.coasterPath);
-  const viewMode = useSceneStore((state) => state.viewMode);
   const simulationSpeed = useSceneStore((state) => state.simulationSpeed);
 
   const { scene: cart } = useGLTF('/objects/cart.glb');
-  const { camera } = useThree();
-
-  const { FIRST_PERSON, THIRD_PERSON, LERP } = SIMULATION_CAMERA;
-
-  const updateCartAndCamera = (newProgress, direction) => {
-    const cartHeightOffset = 2;
-    const currentPosition = coasterPath.getPointAt(newProgress);
-
-    const { rotationQuaternion, adjustedUp } = getRotationFromDirection(direction);
-
-    const raisedPosition = currentPosition.add(adjustedUp.multiplyScalar(cartHeightOffset));
-
-    cartRef.current.position.copy(raisedPosition);
-    cartRef.current.quaternion.copy(rotationQuaternion);
-
-    if (viewMode === 'firstPerson') {
-      const upFromCart = adjustedUp.clone().multiplyScalar(FIRST_PERSON.UP_OFFSET);
-      const inFrontOfCart = direction.clone().multiplyScalar(FIRST_PERSON.FORWARD_OFFSET);
-      const cameraPosition = currentPosition.clone().add(upFromCart).add(inFrontOfCart);
-      const lookAtPoint = currentPosition
-        .clone()
-        .add(direction.clone().multiplyScalar(FIRST_PERSON.LOOK_AHEAD));
-
-      camera.position.copy(cameraPosition);
-      camera.lookAt(lookAtPoint);
-    } else if (viewMode === 'thirdPerson') {
-      const behindCart = direction.clone().multiplyScalar(THIRD_PERSON.BACKWARD_OFFSET);
-
-      behindCart.y += THIRD_PERSON.HEIGHT_OFFSET;
-      const cameraPosition = raisedPosition.clone().add(behindCart);
-
-      camera.position.lerp(cameraPosition, LERP);
-      camera.lookAt(raisedPosition);
-    }
-  };
+  const syncCartAndCamera = useSyncCartAndCamera(cartRef);
 
   useEffect(() => {
     setSimulationProgress(0);
@@ -63,13 +27,13 @@ const CartFollower = () => {
     if (shouldSkipFrame) {
       return;
     }
+
     const direction = coasterPath.getTangentAt(simulationProgress);
     const cartSpeed = getCartSpeed(direction);
-
     const nextProgress = Math.min(simulationProgress + delta * cartSpeed * simulationSpeed, 1);
 
     setSimulationProgress(nextProgress);
-    updateCartAndCamera(nextProgress, direction);
+    syncCartAndCamera(nextProgress, direction);
   });
 
   return <primitive ref={cartRef} object={cart} scale={[1, 1, 0.8]} />;

--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -2,7 +2,12 @@ import { useGLTF } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 
-import { BASE_CART_SPEED, MIN_CART_SPEED, SPEED_REDUCTION } from '@/constants/cartSpeed';
+import {
+  BASE_CART_SPEED,
+  MIN_CART_SPEED,
+  SPEED_ACCELERATION,
+  SPEED_REDUCTION,
+} from '@/constants/cartSpeed';
 import { SIMULATION_CAMERA } from '@/constants/simulationCamera';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getRotationFromDirection } from '@/utils/getRotationFromDirection';
@@ -58,6 +63,9 @@ const CartFollower = () => {
       const reducedSpeed = BASE_CART_SPEED - direction.y * SPEED_REDUCTION;
 
       return Math.max(reducedSpeed, MIN_CART_SPEED);
+    }
+    if (direction.y < 0) {
+      return BASE_CART_SPEED + Math.abs(direction.y) * SPEED_ACCELERATION;
     }
 
     return BASE_CART_SPEED;

--- a/src/components/scene/simulation/CartFollower.jsx
+++ b/src/components/scene/simulation/CartFollower.jsx
@@ -2,14 +2,9 @@ import { useGLTF } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 
-import {
-  BASE_CART_SPEED,
-  MIN_CART_SPEED,
-  SPEED_ACCELERATION,
-  SPEED_REDUCTION,
-} from '@/constants/cartSpeed';
 import { SIMULATION_CAMERA } from '@/constants/simulationCamera';
 import { useSceneStore } from '@/store/useSceneStore';
+import { getCartSpeed } from '@/utils/getCartSpeed';
 import { getRotationFromDirection } from '@/utils/getRotationFromDirection';
 
 const CartFollower = () => {
@@ -56,19 +51,6 @@ const CartFollower = () => {
       camera.position.lerp(cameraPosition, LERP);
       camera.lookAt(raisedPosition);
     }
-  };
-
-  const getCartSpeed = (direction) => {
-    if (direction.y > 0) {
-      const reducedSpeed = BASE_CART_SPEED - direction.y * SPEED_REDUCTION;
-
-      return Math.max(reducedSpeed, MIN_CART_SPEED);
-    }
-    if (direction.y < 0) {
-      return BASE_CART_SPEED + Math.abs(direction.y) * SPEED_ACCELERATION;
-    }
-
-    return BASE_CART_SPEED;
   };
 
   useEffect(() => {

--- a/src/constants/cartSpeed.js
+++ b/src/constants/cartSpeed.js
@@ -1,3 +1,4 @@
-export const BASE_CART_SPEED = 0.3;
+export const BASE_CART_SPEED = 0.1;
 export const SPEED_REDUCTION = 0.3;
+export const SPEED_ACCELERATION = 0.15;
 export const MIN_CART_SPEED = 0.05;

--- a/src/hooks/useSyncCartAndCamera.js
+++ b/src/hooks/useSyncCartAndCamera.js
@@ -1,0 +1,45 @@
+import { useThree } from '@react-three/fiber';
+
+import { SIMULATION_CAMERA } from '@/constants/simulationCamera';
+import { useSceneStore } from '@/store/useSceneStore';
+import { getRotationFromDirection } from '@/utils/getRotationFromDirection';
+
+export const useSyncCartAndCamera = (cartRef) => {
+  const { camera } = useThree();
+  const coasterPath = useSceneStore((state) => state.coasterPath);
+  const viewMode = useSceneStore((state) => state.viewMode);
+  const { FIRST_PERSON, THIRD_PERSON, LERP } = SIMULATION_CAMERA;
+
+  const updateCartAndCamera = (newProgress, direction) => {
+    const cartHeightOffset = 2;
+    const currentPosition = coasterPath.getPointAt(newProgress);
+
+    const { rotationQuaternion, adjustedUp } = getRotationFromDirection(direction);
+    const raisedPosition = currentPosition.add(adjustedUp.multiplyScalar(cartHeightOffset));
+
+    cartRef.current.position.copy(raisedPosition);
+    cartRef.current.quaternion.copy(rotationQuaternion);
+
+    if (viewMode === 'firstPerson') {
+      const upFromCart = adjustedUp.clone().multiplyScalar(FIRST_PERSON.UP_OFFSET);
+      const inFrontOfCart = direction.clone().multiplyScalar(FIRST_PERSON.FORWARD_OFFSET);
+      const cameraPosition = currentPosition.clone().add(upFromCart).add(inFrontOfCart);
+      const lookAtPoint = currentPosition
+        .clone()
+        .add(direction.clone().multiplyScalar(FIRST_PERSON.LOOK_AHEAD));
+
+      camera.position.copy(cameraPosition);
+      camera.lookAt(lookAtPoint);
+    } else {
+      const behindCart = direction.clone().multiplyScalar(THIRD_PERSON.BACKWARD_OFFSET);
+
+      behindCart.y += THIRD_PERSON.HEIGHT_OFFSET;
+      const cameraPosition = raisedPosition.clone().add(behindCart);
+
+      camera.position.lerp(cameraPosition, LERP);
+      camera.lookAt(raisedPosition);
+    }
+  };
+
+  return updateCartAndCamera;
+};

--- a/src/utils/getCartSpeed.js
+++ b/src/utils/getCartSpeed.js
@@ -6,13 +6,20 @@ import {
 } from '@/constants/cartSpeed';
 
 export const getCartSpeed = (direction) => {
-  if (direction.y > 0) {
-    const reducedSpeed = BASE_CART_SPEED - direction.y * SPEED_REDUCTION;
+  const isUphill = direction.y > 0;
+  const isDownhill = direction.y < 0;
+
+  if (isUphill) {
+    const uphillSlowdown = direction.y * SPEED_REDUCTION;
+    const reducedSpeed = BASE_CART_SPEED - uphillSlowdown;
 
     return Math.max(reducedSpeed, MIN_CART_SPEED);
   }
-  if (direction.y < 0) {
-    return BASE_CART_SPEED + Math.abs(direction.y) * SPEED_ACCELERATION;
+
+  if (isDownhill) {
+    const downhillBoost = Math.abs(direction.y) * SPEED_ACCELERATION;
+
+    return BASE_CART_SPEED + downhillBoost;
   }
 
   return BASE_CART_SPEED;

--- a/src/utils/getCartSpeed.js
+++ b/src/utils/getCartSpeed.js
@@ -1,0 +1,19 @@
+import {
+  BASE_CART_SPEED,
+  MIN_CART_SPEED,
+  SPEED_ACCELERATION,
+  SPEED_REDUCTION,
+} from '@/constants/cartSpeed';
+
+export const getCartSpeed = (direction) => {
+  if (direction.y > 0) {
+    const reducedSpeed = BASE_CART_SPEED - direction.y * SPEED_REDUCTION;
+
+    return Math.max(reducedSpeed, MIN_CART_SPEED);
+  }
+  if (direction.y < 0) {
+    return BASE_CART_SPEED + Math.abs(direction.y) * SPEED_ACCELERATION;
+  }
+
+  return BASE_CART_SPEED;
+};


### PR DESCRIPTION
## 🔗 Related Issue
- close #82

## 📝 Done Task
- [x] 카트 주행 속도 조절 로직 개선
`BASE_CART_SPEED`를 0.1로 하향 조정
내리막 경사(y < 0)일 때 `SPEED_ACCELERATION` 값만큼 가속 적용
- [x] getCartSpeed 유틸 함수로 추출하여 로직 분리
- [x] 카트 및 카메라 동기화 로직 useSyncCartAndCamera 훅으로 분리

## 🔎 PR Point
- 기존에는 오르막 경사에서만 감속 로직이 존재했으며, 평지/내리막 구간 구분 없이 동일한 속도를 유지해 몰입도가 떨어졌습니다.
- 이를 개선하기 위해 내리막일 때 가속이 적용되도록 로직을 추가했고, 기본 속도를 조정해 1인칭 시점에서도 속도가 너무 빠르지 않도록 수정했습니다.
- 주행 로직과 시각적 업데이트가 뒤섞여 있던 기존 구조를 훅으로 분리했습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/bd25ba8f-1142-4419-a970-3baf6b3a6459



