### PR TITLE
Feat: GLB 모델 프리로드 기능 구현

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,9 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from '@/App';
+import { preloadModels } from '@/utils/preloadModels';
+
+preloadModels();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/utils/preloadModels.js
+++ b/src/utils/preloadModels.js
@@ -1,0 +1,23 @@
+import { useGLTF } from '@react-three/drei';
+
+export const preloadModels = () => {
+  useGLTF.preload('/objects/rail/straight.glb');
+  useGLTF.preload('/objects/rail/curve-left.glb');
+  useGLTF.preload('/objects/rail/curve-right.glb');
+  useGLTF.preload('/objects/rail/up-start.glb');
+  useGLTF.preload('/objects/rail/up-middle.glb');
+  useGLTF.preload('/objects/rail/up-end.glb');
+  useGLTF.preload('/objects/rail/up-slope-full.glb');
+  useGLTF.preload('/objects/rail/down-start.glb');
+  useGLTF.preload('/objects/rail/down-middle.glb');
+  useGLTF.preload('/objects/rail/down-end.glb');
+  useGLTF.preload('/objects/rail/down-slope-full.glb');
+  useGLTF.preload('/objects/coaster/cart.glb');
+  useGLTF.preload('/objects/coaster/entrance.glb');
+  useGLTF.preload('/objects/item/bench.glb');
+  useGLTF.preload('/objects/item/bumper-car.glb');
+  useGLTF.preload('/objects/item/coffee-cart.glb');
+  useGLTF.preload('/objects/item/ferris-wheel.glb');
+  useGLTF.preload('/objects/item/ice-cream-car.glb');
+  useGLTF.preload('/objects/environment/tree.glb');
+};


### PR DESCRIPTION
## 🔗 Related Issue
- close #90

## 📝 Done Task
- [x] `useGLTF.preload()`를 활용한 모델 프리로드 함수 구현
- [x] `main.jsx` 진입 시점에서 `preloadModels()` 호출 적용

## 🔎 PR Point
- GLB 모델 로딩 시 깜빡임 문제를 줄이기 위해 `@react-three/drei`의 `useGLTF.preload()` 기능을 도입했습니다.
- 모든 트랙, 소품, 환경 요소 등에 사용되는 .glb 모델들을 한 번에 사전 로딩하도록 `preloadModels` 유틸 함수를 작성했습니다.
- 해당 함수는 `main.jsx`에서 앱이 렌더링되기 전에 호출되며, 최초 진입 시점에서 리소스를 미리 불러옵니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/2e609861-da34-4b25-a6d7-89c096723f92

