### PR TITLE
Feat: 충돌 처리 구현 (아이템 및 레일)

### DIFF
--- a/src/hooks/usePlaceRails.js
+++ b/src/hooks/usePlaceRails.js
@@ -1,10 +1,13 @@
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 
 import { POINT_TEMPLATES } from '@/constants/rail/pointTemplates';
 import { ROTATION_MAP } from '@/constants/rail/rotationMap';
+import { useItemStore } from '@/store/useItemStore';
 import { useRailStore } from '@/store/useRailStore';
 import { isGroundCollision } from '@/utils/isGroundCollision';
+import { isObjectCollidingWithSceneObjects } from '@/utils/isObjectCollidingWithSceneObjects';
 import { getWorldRailPoints } from '@/utils/rail/getWorldRailPoints';
 import { getModelPathByName } from '@/utils/sceneAssetUtils';
 
@@ -12,46 +15,85 @@ export const usePlaceRails = (initialRails = []) => {
   const selectedRail = useRailStore((state) => state.selectedRail);
   const placedRails = useRailStore((state) => state.placedRails);
   const setPlacedRails = useRailStore((state) => state.setPlacedRails);
+  const placedItems = useItemStore((state) => state.placedItems);
 
   useEffect(() => {
     setPlacedRails(initialRails);
-  }, []);
+  }, [initialRails]);
 
   useEffect(() => {
     if (!selectedRail) {
       return;
     }
 
-    const lastPlacedRail = placedRails.at(-1);
-    const startPosition = lastPlacedRail.endPoint;
-    const previousYRotation = lastPlacedRail.accumulatedYRotation;
+    const placeRail = async () => {
+      const lastPlacedRail = placedRails.at(-1);
+      const startPosition = lastPlacedRail.endPoint;
+      const previousYRotation = lastPlacedRail.accumulatedYRotation;
 
-    const railPoints = POINT_TEMPLATES[selectedRail.name];
-    const currentRailYRotation = ROTATION_MAP[selectedRail.name] ?? 0;
-    const accumulatedYRotation = previousYRotation + currentRailYRotation;
-    const worldPoints = getWorldRailPoints(railPoints, startPosition, [0, previousYRotation, 0]);
-    const endPosition = worldPoints.at(-1);
+      const railPoints = POINT_TEMPLATES[selectedRail.name];
+      const currentRailYRotation = ROTATION_MAP[selectedRail.name] ?? 0;
+      const accumulatedYRotation = previousYRotation + currentRailYRotation;
+      const worldPoints = getWorldRailPoints(railPoints, startPosition, [0, previousYRotation, 0]);
+      const endPosition = worldPoints.at(-1);
 
-    const newRail = {
-      id: selectedRail.id,
-      modelPath: getModelPathByName(selectedRail.name),
-      position: startPosition,
-      rotation: [0, previousYRotation, 0],
-      points: worldPoints,
-      endPoint: endPosition,
-      accumulatedYRotation,
+      const newRail = {
+        id: selectedRail.id,
+        modelPath: getModelPathByName(selectedRail.name),
+        position: startPosition,
+        rotation: [0, previousYRotation, 0],
+        points: worldPoints,
+        endPoint: endPosition,
+        accumulatedYRotation,
+      };
+
+      if (isGroundCollision(newRail)) {
+        toast.error('레일 설치 실패: 지형과 충돌했습니다');
+
+        return;
+      }
+
+      try {
+        const modelLoader = new GLTFLoader();
+
+        const hasItemCollision = await newRail.points.reduce(async (prevPromise, point) => {
+          const isCollisionFound = await prevPromise;
+
+          if (isCollisionFound) {
+            return true;
+          }
+
+          const gltf = await modelLoader.loadAsync(newRail.modelPath);
+          const mesh = gltf.scene.clone();
+
+          mesh.position.set(...point);
+          mesh.rotation.set(...newRail.rotation);
+
+          const isItemCollision = await isObjectCollidingWithSceneObjects({
+            targetObject: mesh,
+            sceneObjects: placedItems,
+            getModelPath: (item) => getModelPathByName(item.name),
+            getPosition: (item) => item.position,
+            getRotation: (item) => [0, item.rotationY || 0, 0],
+          });
+
+          return isItemCollision;
+        }, Promise.resolve(false));
+
+        if (hasItemCollision) {
+          toast.error('레일 설치 실패: 아이템과 충돌했습니다');
+
+          return;
+        }
+
+        setPlacedRails([...placedRails, newRail]);
+      } catch (err) {
+        toast.error('레일 설치 실패: 모델 로딩 오류');
+      }
     };
 
-    const isCollidingWithGround = isGroundCollision(newRail);
-
-    if (isCollidingWithGround) {
-      toast.error('레일 설치 실패: 지형과 충돌했습니다');
-
-      return;
-    }
-
-    setPlacedRails([...placedRails, newRail]);
-  }, [selectedRail]);
+    placeRail();
+  }, [selectedRail, placedItems, placedRails, setPlacedRails]);
 
   return placedRails;
 };

--- a/src/utils/isObjectCollidingWithSceneObjects.js
+++ b/src/utils/isObjectCollidingWithSceneObjects.js
@@ -1,0 +1,39 @@
+import toast from 'react-hot-toast';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
+export const isObjectCollidingWithSceneObjects = async ({
+  targetObject,
+  sceneObjects,
+  getModelPath,
+  getPosition,
+  getRotation,
+}) => {
+  const modelLoader = new GLTFLoader();
+  const targetBox = new THREE.Box3().setFromObject(targetObject);
+
+  const results = await Promise.all(
+    sceneObjects.map(async (obj) => {
+      try {
+        const modelPath = getModelPath(obj);
+        const gltf = await modelLoader.loadAsync(modelPath);
+        const sceneObj = gltf.scene.clone();
+
+        sceneObj.position.set(...getPosition(obj));
+        if (getRotation) {
+          sceneObj.rotation.set(...getRotation(obj));
+        }
+
+        const objBox = new THREE.Box3().setFromObject(sceneObj);
+
+        return targetBox.intersectsBox(objBox);
+      } catch (error) {
+        toast.error('설치할 수 없습니다.');
+
+        return true;
+      }
+    }),
+  );
+
+  return results.some(Boolean);
+};


### PR DESCRIPTION
## 🔗 Related Issue
- close #85 

## 📝 Done Task
- [x] 아이템 설치 시 레일과의 충돌 검사 추가
- [x] 레일 설치 시 경로 전반의 충돌 검사 추가
- [x] 범용 충돌 검사 유틸 함수로 구현

## 🔎 PR Point

1. 레일 설치 시 충돌 경로 전체 검사 
   - `newRail.points` 배열을 기준으로 모델을 각 포인트에 배치하고 충돌을 확인했습니다.
   - 이동 경로 중간에 장애물이 있어도 감지할 수 있도록 했습니다.

2. 아이템 설치 시 레일 및 다른 아이템과의 충돌 체크 적용
   - 충돌 검사 유틸 `isObjectCollidingWithSceneObjects`를 통해 기존에 배치된 아이템 및 레일과 겹치는지 감지할 수 있도록 했습니다.

3. 충돌 발견 시 즉시 설치를 중단하는 구조 구현
   - 아이템 충돌, 지형 충돌 시 사용자에게 오류 메세지를 제공하였습니다.

4. 충돌 검사 유틸함수로 구현하여 재사용성 고려
   - `isObjectCollidingWithSceneObjects`를 활용해 아이템, 레일모두에 충돌 검사를 적용하였습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/920b78dc-aead-460a-adac-7bd9a672d0f3

